### PR TITLE
⬇️ (persistence): Downgrade of LiteDB from 5.0.19 to 5.0.17

### DIFF
--- a/BaseBotService/BaseBotService.csproj
+++ b/BaseBotService/BaseBotService.csproj
@@ -40,7 +40,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="LiteDB" Version="5.0.19" />
+        <PackageReference Include="LiteDB" Version="5.0.17" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />


### PR DESCRIPTION
The updated version of LiteDB causes issues with running the unit tests, and possibly with the application itself. This is a temporary downgrade until the issues are resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the LiteDB package version for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->