### PR TITLE
Fix issue #303: replace obsolete attribute

### DIFF
--- a/BaseBotService/Commands/AdminModule.cs
+++ b/BaseBotService/Commands/AdminModule.cs
@@ -3,7 +3,7 @@
 namespace BaseBotService.Commands;
 
 [Group("admin", "Administration of the bot for the current server.")]
-[EnabledInDm(false)]
+[CommandContextType(InteractionContextType.Guild)]
 [RequireUserPermission(GuildPermission.Administrator)]
 public class AdminModule : BaseModule
 {

--- a/BaseBotService/Commands/BotModule.cs
+++ b/BaseBotService/Commands/BotModule.cs
@@ -1,4 +1,4 @@
-﻿using BaseBotService.Core.Base;
+using BaseBotService.Core.Base;
 using BaseBotService.Utilities;
 using BaseBotService.Utilities.Attributes;
 
@@ -8,6 +8,9 @@ namespace BaseBotService.Commands;
 [CommandContextType(InteractionContextType.Guild, InteractionContextType.BotDm)]
 public class BotModule : BaseModule
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BotModule"/> class with a scoped logger.
+    /// </summary>
     public BotModule(ILogger logger)
     {
         Logger = logger.ForContext<BotModule>();

--- a/BaseBotService/Commands/BotModule.cs
+++ b/BaseBotService/Commands/BotModule.cs
@@ -5,7 +5,7 @@ using BaseBotService.Utilities.Attributes;
 namespace BaseBotService.Commands;
 
 [Group("bot", "The main bot information module of Honeycomb.")]
-[EnabledInDm(true)]
+[CommandContextType(InteractionContextType.Guild, InteractionContextType.BotDm)]
 public class BotModule : BaseModule
 {
     public BotModule(ILogger logger)


### PR DESCRIPTION
## Summary
- replace `[EnabledInDm]` attributes that are obsolete with `[CommandContextType]`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68405cde13d88324b698b541af2ec487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated command availability to provide clearer and more consistent access: Admin commands are now only available within servers, while bot commands are available in both servers and direct messages with the bot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->