### PR TITLE
Fix documentation typos and division bug

### DIFF
--- a/BaseBotService/Commands/UserModule.cs
+++ b/BaseBotService/Commands/UserModule.cs
@@ -264,6 +264,10 @@ public class UserModule : BaseModule
         double maxPoints = daysCounting * _engagementService.MaxPointsPerDay;
         double scaledMaxPoints = maxPoints * scalingFactor;
         Logger.Debug($"User {user!.Id} has been in the guild for {daysCounting} days, which would result in {maxPoints} points. The scaling factor is {scalingFactor}, so the maximum points are {scaledMaxPoints}.");
+        if (Math.Abs(scaledMaxPoints) < double.Epsilon)
+        {
+            return 0;
+        }
         return Math.Min(100, _engagementService.GetActivityPoints(user.GuildId, user.Id) / scaledMaxPoints * 100);
     }
 

--- a/BaseBotServiceTests/Commands/UserModuleTests.cs
+++ b/BaseBotServiceTests/Commands/UserModuleTests.cs
@@ -41,7 +41,7 @@ public class UserModuleTests
         double result = _userModule.GetActivityScore(user, bot);
 
         // Assert
-        result.ShouldBe(0);
+        result.ShouldBe(0, 1.0);
     }
 
     [TestCase((uint)85, 100)]
@@ -75,5 +75,32 @@ public class UserModuleTests
 
         // Assert
         result.ShouldBe(score, 1.0);
+    }
+
+    [Test]
+    public void GetActivityScore_ShouldReturnZero_WhenUserAndBotJoinedAtSameTime()
+    {
+        // Arrange
+        var joinedAt = DateTimeOffset.UtcNow;
+        ulong guildId = _faker.Random.ULong();
+        ulong userId = _faker.Random.ULong();
+
+        var user = Substitute.For<IGuildUser>();
+        user.JoinedAt.Returns(joinedAt);
+        user.GuildId.Returns(guildId);
+        user.Id.Returns(userId);
+
+        var bot = Substitute.For<IGuildUser>();
+        bot.JoinedAt.Returns(joinedAt);
+        bot.GuildId.Returns(guildId);
+
+        _engagementService.MaxPointsPerDay.Returns(0);
+        _engagementService.GetActivityPoints(guildId, userId).Returns((uint)50);
+
+        // Act
+        double result = _userModule.GetActivityScore(user, bot);
+
+        // Assert
+        result.ShouldBe(0, 1.0);
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Project Honeycomb is a Discord bot designed to provide artists with some useful 
 - **Raffles:** Organize raffles on Discord or Twitter and randomly draw the winners.
 - **Artist Discovery:** Opt-in to be discoverable when being open for commissions within a global catalogue.
 - **Ideas & Suggestions:** Collect new ideas for your drawings from your fans and let them vote for their favorites.
-- **Portfolio Webpage:** Publish all your information also on a public website, making them accessable worldwide even outside of Discord.
+- **Portfolio Webpage:** Publish all your information also on a public website, making them accessible worldwide even outside of Discord.
 
 ## Installation
 
@@ -38,7 +38,7 @@ Project Honeycomb is a Discord bot designed to provide artists with some useful 
 
 ## License
 
-📝 Project Honeycomb is released under the [MIT License](LICENSE.txt).
+📝 Project Honeycomb is released under the [MIT License](LICENSE).
 
 [Logo](https://www.flaticon.com/free-icon/bee_7299846?term=bee&page=1&position=41&origin=tag&related_id=7299846): <a href="https://www.flaticon.com/free-icons/bee" title="bee icons">Bee icons created by Deylotus Creative Design - Flaticon</a>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -396,7 +396,7 @@
             href="https://github.com/JastinXyz/discord-bot-landing-page-web"
             class="blurple has-text-weight-bold"
             target="_blank"
-            >Github</a
+            >GitHub</a
           >
         </p>
       </div>


### PR DESCRIPTION
## Summary
- fix accessible typo and license link in README
- correct GitHub text in website docs
- guard against division by zero in `GetActivityScore`
- add test for zero scale scenario
- use tolerance for floating point comparisons

## Testing
- `dotnet build Honeycomb.sln`
- `dotnet test Honeycomb.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6840510ac3ec832494366e1a6ad5aced