### PR TITLE
Add server activity leaderboard

### DIFF
--- a/BaseBotService/Core/DiscordEventListener.cs
+++ b/BaseBotService/Core/DiscordEventListener.cs
@@ -41,6 +41,7 @@ public class DiscordEventListener
         _client.JoinedGuild += (guild) => _mediator.Publish(new JoinedGuildNotification(guild), _cancellationToken);
         _client.LeftGuild += (guild) => _mediator.Publish(new LeftGuildNotification(guild), _cancellationToken);
         _client.UserJoined += (user) => _mediator.Publish(new UserJoinedNotification(user), _cancellationToken);
+        _client.UserLeft += (guild, user) => _mediator.Publish(new UserLeftNotification(guild, user), _cancellationToken);
         _handler.Log += (msg) => _mediator.Publish(new LogNotification(msg), _cancellationToken);
 
         _ = await _handler.AddModulesAsync(Assembly.GetEntryAssembly(), _services);

--- a/BaseBotService/Core/Messages/UserLeftNotification.cs
+++ b/BaseBotService/Core/Messages/UserLeftNotification.cs
@@ -1,0 +1,14 @@
+using Discord.WebSocket;
+
+namespace BaseBotService.Core.Messages;
+public class UserLeftNotification : INotification
+{
+    public SocketGuild Guild { get; }
+    public SocketUser User { get; }
+
+    public UserLeftNotification(SocketGuild guild, SocketUser user)
+    {
+        Guild = guild;
+        User = user;
+    }
+}

--- a/BaseBotService/Data/Interfaces/IGuildMemberRepository.cs
+++ b/BaseBotService/Data/Interfaces/IGuildMemberRepository.cs
@@ -36,4 +36,12 @@ public interface IGuildMemberRepository
     /// <returns>True if the delete was successful, otherwise false.</returns>
     bool DeleteUser(ulong guildId, ulong userId);
     int DeleteGuild(ulong guildId);
+
+    /// <summary>
+    /// Gets the top users of a guild ordered by their activity points.
+    /// </summary>
+    /// <param name="guildId">The unique identifier of the guild.</param>
+    /// <param name="limit">The maximum number of users to return.</param>
+    /// <returns>An enumerable of <see cref="GuildMemberHC"/> ordered by activity points.</returns>
+    IEnumerable<GuildMemberHC> GetTopUsers(ulong guildId, int limit);
 }

--- a/BaseBotService/Data/Repositories/GuildMemberRepository.cs
+++ b/BaseBotService/Data/Repositories/GuildMemberRepository.cs
@@ -38,4 +38,10 @@ public class GuildMemberRepository : IGuildMemberRepository
         }
         return 0;
     }
+
+    public IEnumerable<GuildMemberHC> GetTopUsers(ulong guildId, int limit)
+        => _guildMembers
+            .Find(a => a.GuildId == guildId)
+            .OrderByDescending(u => u.ActivityPoints)
+            .Take(limit);
 }

--- a/BaseBotService/Interactions/EntityLifecycleHandler.cs
+++ b/BaseBotService/Interactions/EntityLifecycleHandler.cs
@@ -4,7 +4,7 @@ using BaseBotService.Data.Interfaces;
 using BaseBotService.Data.Models;
 
 namespace BaseBotService.Interactions;
-public class EntityLifecycleHandler : INotificationHandler<JoinedGuildNotification>, INotificationHandler<UserJoinedNotification>, INotificationHandler<LeftGuildNotification>
+public class EntityLifecycleHandler : INotificationHandler<JoinedGuildNotification>, INotificationHandler<UserJoinedNotification>, INotificationHandler<LeftGuildNotification>, INotificationHandler<UserLeftNotification>
 {
     private readonly ILogger _logger;
     private readonly IMemberRepository _memberRepository;
@@ -51,6 +51,21 @@ public class EntityLifecycleHandler : INotificationHandler<JoinedGuildNotificati
 
         _guildRepository.AddGuild(new GuildHC { GuildId = notification.Guild.Id });
         _logger.Information($"Bot joined {notification.Guild.Id}, created GuildHC.");
+
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(UserLeftNotification notification, CancellationToken cancellationToken)
+    {
+        _logger.Debug($"{nameof(EntityLifecycleHandler)} received {nameof(UserLeftNotification)}");
+
+        GuildMemberHC? member = _guildMemberRepository.GetUser(notification.Guild.Id, notification.User.Id);
+        if (member != null)
+        {
+            member.ActivityPoints = 0;
+            _guildMemberRepository.UpdateUser(member);
+            _logger.Information($"User {notification.User.Id} left {notification.Guild.Id}, reset ActivityPoints.");
+        }
 
         return Task.CompletedTask;
     }

--- a/BaseBotService/Locales/de.ftl
+++ b/BaseBotService/Locales/de.ftl
@@ -134,6 +134,9 @@ profile = { $username } @ { $guildname }
    *[other] Invalid activity score
 }
 
+leaderboard-title = Top { $amount } active users
+leaderboard-entry = { $rank }. { $user } - { $points } pts
+
 
 
 

--- a/BaseBotService/Locales/en.ftl
+++ b/BaseBotService/Locales/en.ftl
@@ -138,6 +138,9 @@ profile = { $username } @ { $guildname }
    *[other] Invalid activity score
 }
 
+leaderboard-title = Top { $amount } active users
+leaderboard-entry = { $rank }. { $user } - { $points } pts
+
 
 
 ####################################

--- a/BaseBotService/Locales/es.ftl
+++ b/BaseBotService/Locales/es.ftl
@@ -134,6 +134,9 @@ profile = { $username } @ { $guildname }
    *[other] Invalid activity score
 }
 
+leaderboard-title = Top { $amount } active users
+leaderboard-entry = { $rank }. { $user } - { $points } pts
+
 
 
 

--- a/BaseBotService/Locales/fr.ftl
+++ b/BaseBotService/Locales/fr.ftl
@@ -134,6 +134,9 @@ profile = { $username } @ { $guildname }
    *[other] Invalid activity score
 }
 
+leaderboard-title = Top { $amount } active users
+leaderboard-entry = { $rank }. { $user } - { $points } pts
+
 
 
 

--- a/BaseBotServiceTests/Commands/UserModuleTests.cs
+++ b/BaseBotServiceTests/Commands/UserModuleTests.cs
@@ -13,6 +13,7 @@ public class UserModuleTests
     private ITranslationService _translationService;
     private IEngagementService _engagementService;
     private IMemberRepository _memberRepository;
+    private IGuildMemberRepository _guildMemberRepository;
     private ILogger _logger;
     private UserModule _userModule;
     private readonly Faker _faker = new();
@@ -23,9 +24,10 @@ public class UserModuleTests
         _translationService = Substitute.For<ITranslationService>();
         _engagementService = Substitute.For<IEngagementService>();
         _memberRepository = Substitute.For<IMemberRepository>();
+        _guildMemberRepository = Substitute.For<IGuildMemberRepository>();
         _logger = Substitute.For<ILogger>();
 
-        _userModule = new UserModule(_logger, _translationService, _engagementService, _memberRepository);
+        _userModule = new UserModule(_logger, _translationService, _engagementService, _memberRepository, _guildMemberRepository);
     }
 
     [Test]

--- a/BaseBotServiceTests/Data/Repositories/GuildMemberRepositoryTests.cs
+++ b/BaseBotServiceTests/Data/Repositories/GuildMemberRepositoryTests.cs
@@ -91,4 +91,28 @@ public class GuildMemberRepositoryTests
         var deletedUser = _guildMembers.FindOne(u => u.MemberId == existingUser.MemberId && u.GuildId == existingUser.GuildId);
         deletedUser.ShouldBeNull();
     }
+
+    [Test]
+    public void GetTopUsers_ShouldReturnOrderedLimitedList()
+    {
+        // Arrange
+        var guild = FakeDataHelper.GuildFaker.Generate();
+        _guilds.Insert(guild);
+        foreach (var member in guild.Members)
+        {
+            _guildMembers.Insert(member);
+        }
+        int limit = Math.Min(3, guild.Members.Count);
+
+        // Act
+        var result = _repository.GetTopUsers(guild.GuildId, limit).ToList();
+
+        // Assert
+        result.Count.ShouldBe(limit);
+        var expected = guild.Members
+            .OrderByDescending(m => m.ActivityPoints)
+            .Take(limit)
+            .Select(m => m.MemberId);
+        result.Select(r => r.MemberId).ShouldBe(expected);
+    }
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Project Honeycomb is a Discord bot designed to provide artists with some useful 
 - **Commission Request Form:** Users can request a commission by filling out a form with necessary details.
 - **OC Reference Management:** Users can add references with descriptions for their OCs to easily access them when needed.
 - **Loyalty Points:** Artists can reward their loyal customers by awarding loyalty points, which can be redeemed for future commissions.
+- **Activity Leaderboard:** See which members are most active in your server.
 - **Announcement of New Art:** Artists can announce their new artwork with references to different platforms like Twitter, DeviantArt, FurAffinity, Patreon, and more.
 - **Progress Tracking of Commissions:** Artists can track the progress of their commissions using the bot.
 - **Raffles:** Organize raffles on Discord or Twitter and randomly draw the winners.


### PR DESCRIPTION
## Summary
- add UserLeftNotification to reset activity points when a member leaves a guild
- expose GetTopUsers in `IGuildMemberRepository`
- implement leaderboard retrieval in repository
- update EntityLifecycleHandler and DiscordEventListener for new notification
- add `/user leaderboard` command
- update translations and README
- add unit tests for leaderboard data access

Fixes #65


------
https://chatgpt.com/codex/tasks/task_e_684200304e1c8324a44fd34abfd81136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an activity leaderboard command to display the most active users in your Discord server.
- **Localization**
  - Added leaderboard-related translations in English, German, Spanish, and French.
- **Bug Fixes**
  - Activity points for users are now reset when a user leaves the server.
- **Documentation**
  - Updated the README to mention the new activity leaderboard feature.
- **Tests**
  - Added and updated tests to cover leaderboard functionality and ensure correct ordering and limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->