### PR TITLE
Handle invalid HEALTH_PORT and guard missing DISCORD_BOT_TOKEN

### DIFF
--- a/BaseBotService/Infrastructure/Services/EnvironmentService.cs
+++ b/BaseBotService/Infrastructure/Services/EnvironmentService.cs
@@ -12,13 +12,16 @@ public class EnvironmentService : IEnvironmentService
 
     public EnvironmentService(ILogger logger, ITranslationService translationService, CancellationTokenSource cts)
     {
-        DiscordBotToken = Environment.GetEnvironmentVariable("DISCORD_BOT_TOKEN")!;
+        DiscordBotToken = Environment.GetEnvironmentVariable("DISCORD_BOT_TOKEN") ?? string.Empty;
         if (string.IsNullOrWhiteSpace(DiscordBotToken))
         {
             logger.Fatal("Environment variable 'DISCORD_BOT_TOKEN' not set.");
             cts.Cancel();
         }
-        logger.Information($"Environment variable 'DISCORD_BOT_TOKEN' set to '{DiscordBotToken.MaskToken()}.'");
+        else
+        {
+            logger.Information($"Environment variable 'DISCORD_BOT_TOKEN' set to '{DiscordBotToken.MaskToken()}.'");
+        }
 
         RegisterCommands = Environment.GetEnvironmentVariable("COMMAND_REGISTER") switch
         {
@@ -28,7 +31,13 @@ public class EnvironmentService : IEnvironmentService
         };
         logger.Information($"Mode for registering commands: '{(int)RegisterCommands}' ({RegisterCommands}).");
 
-        HealthPort = int.Parse(Environment.GetEnvironmentVariable("HEALTH_PORT") ?? "8080");
+        string? healthPortValue = Environment.GetEnvironmentVariable("HEALTH_PORT");
+        if (!int.TryParse(healthPortValue, out int healthPort) || healthPort is < 1 or > 65535)
+        {
+            logger.Warning("Environment variable 'HEALTH_PORT' value '{HealthPortValue}' is invalid. Using default port 8080.", healthPortValue);
+            healthPort = 8080;
+        }
+        HealthPort = healthPort;
         logger.Information($"http-port for health probe set to '{HealthPort}'.");
 
         ConnectionString = Environment.GetEnvironmentVariable("ConnectionString") ?? "Filename=honeycomb.db;";

--- a/BaseBotServiceTests/Infrastructure/Services/EnvironmentServiceTests.cs
+++ b/BaseBotServiceTests/Infrastructure/Services/EnvironmentServiceTests.cs
@@ -1,0 +1,56 @@
+using BaseBotService.Core.Interfaces;
+using BaseBotService.Infrastructure.Services;
+using Serilog;
+
+namespace BaseBotService.Tests.Infrastructure.Services;
+
+[TestFixture]
+public class EnvironmentServiceTests
+{
+    private string? _originalBotToken;
+    private string? _originalHealthPort;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _originalBotToken = Environment.GetEnvironmentVariable("DISCORD_BOT_TOKEN");
+        _originalHealthPort = Environment.GetEnvironmentVariable("HEALTH_PORT");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("DISCORD_BOT_TOKEN", _originalBotToken);
+        Environment.SetEnvironmentVariable("HEALTH_PORT", _originalHealthPort);
+    }
+
+    [Test]
+    public void Constructor_WhenHealthPortIsInvalid_UsesDefaultPort()
+    {
+        Environment.SetEnvironmentVariable("DISCORD_BOT_TOKEN", "test-token");
+        Environment.SetEnvironmentVariable("HEALTH_PORT", "not-a-number");
+
+        var logger = Substitute.For<ILogger>();
+        var translationService = Substitute.For<ITranslationService>();
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        var service = new EnvironmentService(logger, translationService, cancellationTokenSource);
+
+        service.HealthPort.ShouldBe(8080);
+    }
+
+    [Test]
+    public void Constructor_WhenHealthPortIsValid_UsesConfiguredPort()
+    {
+        Environment.SetEnvironmentVariable("DISCORD_BOT_TOKEN", "test-token");
+        Environment.SetEnvironmentVariable("HEALTH_PORT", "9001");
+
+        var logger = Substitute.For<ILogger>();
+        var translationService = Substitute.For<ITranslationService>();
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        var service = new EnvironmentService(logger, translationService, cancellationTokenSource);
+
+        service.HealthPort.ShouldBe(9001);
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent startup crashes and confusing logs when required environment values are missing or malformed by validating `HEALTH_PORT` and avoiding logging a missing `DISCORD_BOT_TOKEN` as if it were set.
- Provide deterministic behavior and coverage by adding unit tests for the new parsing logic.

### Description
- Changed `EnvironmentService` to treat `DISCORD_BOT_TOKEN` as empty when unset and only log the masked token when present, and to cancel startup when the token is missing (`BaseBotService/Infrastructure/Services/EnvironmentService.cs`).
- Replaced `int.Parse(...)` for `HEALTH_PORT` with `int.TryParse(...)` and a bounds check, falling back to port `8080` when the value is invalid or out of range, and emitting a warning log (`BaseBotService/Infrastructure/Services/EnvironmentService.cs`).
- Added unit tests `EnvironmentServiceTests` that verify the default port is used for invalid input and that a valid port is respected (`BaseBotServiceTests/Infrastructure/Services/EnvironmentServiceTests.cs`).
- No Codex skills were used for this change (no skill invocation was needed).

### Testing
- Added automated NUnit tests in `BaseBotServiceTests/Infrastructure/Services/EnvironmentServiceTests.cs` but they were not executed in this environment because running `dotnet test` failed due to `dotnet` not being available (test run unavailable).
- Local static inspections and repository checks were performed; no runtime test results are available from this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749fe3ec348324bd4b92acb45bae9a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added port validation for health check configuration with range checking (1-65535) and automatic fallback to default port for invalid values.
  * Improved token configuration handling with enhanced logging.

* **Tests**
  * Added unit tests for configuration validation and fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->